### PR TITLE
CR State manipulation via ENV variables + bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,888 @@ clean:
 		echo ">> Removing $$id"; \
 		$(DOCKER) rmi -f $$id; \
 	done
+
+
+### Experiments
+
+experiment_1_10:
+	sudo rm /vagrant/quicopsat-stage2/quiche_latest/logs/exp1/10/*
+	sudo python /vagrant/quicopsat-stage2/quiche_latest/mn_script.py /vagrant/quicopsat-stage2/quiche_latest/logs/exp1/10 10
+
+experiment_1_100:
+	sudo rm /vagrant/quicopsat-stage2/quiche_latest/logs/exp1/100/*
+	sudo python /vagrant/quicopsat-stage2/quiche_latest/mn_script.py /vagrant/quicopsat-stage2/quiche_latest/logs/exp1/100 100
+
+
+experiment_1:
+	echo "Testing 1MB CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/1 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/1M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+	echo "Testing 1MB NO CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/1/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/1M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 2MB CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/2 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/2M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 2MB no CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/2/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/2M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 5MB CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/5 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/5M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+	echo "Testing 5MB NO CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/5/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/5M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 20MB CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/20 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+	echo "Testing 20MB NO CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/20/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 50MB CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/50 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/50M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+	echo "Testing 50MB NO CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/50/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/50M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 100MB CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/100 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+	echo "Testing 100MB NO CR"
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/100/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+experiment_1_high_IW:
+	echo "Testing 1MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/1/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/1/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/1M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 2MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/2/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/2/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/2M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 5MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/5/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/5/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/5M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/10/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/10/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 20MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/20/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/20/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 50MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/50/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/50/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/50M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 100MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/100/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/100/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000  --initial-cwnd-packets 1400 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+aux:
+	echo "Testing 100MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/100/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/100/high_iw && unset PREVIOUS_CWND_BYTES && unset PREVIOUS_RTT  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..3} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+fq_link:
+	echo "Testing 20MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/fq_link
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp1/fq_link && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+fq_fq_codel_link:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq_codel
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_codel_intf
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_codel_intf/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_codel_intf/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_codel_intf/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_codel_intf/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+
+fq_fq_codel_link_no_pacing:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq_codel
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_codel_intf/no_pacing
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_codel_intf/no_pacing/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_codel_intf/no_pacing/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 --disable-pacing &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_codel_intf/no_pacing/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_codel_intf/no_pacing/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+fq_fq_link:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_intf
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_intf/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_intf/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_intf/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_intf/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+
+fq_fq_link_no_pacing:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_intf/no_pacing
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_intf/no_pacing/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq/fq_intf/no_pacing/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 --disable-pacing &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_intf/no_pacing/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_intf/no_pacing/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+
+fq_codel_fq_codel_link:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq_codel
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_codel_intf
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_codel_intf/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_codel_intf/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_codel/fq_codel_intf/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_codel/fq_codel_intf/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+
+fq_codel_fq_codel_link_no_pacing:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq_codel
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_codel_intf/no_pacing
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_codel_intf/no_pacing/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_codel_intf/no_pacing/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 --disable-pacing &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_codel/fq_codel_intf/no_pacing/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_codel/fq_codel_intf/no_pacing/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+
+fq_codel_fq_link:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_intf
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_intf/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_intf/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_codel/fq_intf/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_codel/fq_intf/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+
+fq_codel_fq_link_no_pacing:
+	echo "Testing with FQ Codel interface link"
+	sudo tc qdisc del dev eth0 root
+	sudo tc qdisc add dev eth0 root fq
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_intf/no_pacing
+	sudo tcpdump -i eth0 port 4433 -w /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_intf/no_pacing/server.pcap &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/pacing_experiments/fq_codel/fq_intf/no_pacing/ && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 300000000 --disable-pacing &
+	@ssh simulator2 "mkdir -p /home/mihail/logs/fq_codel/fq_intf/no_pacing/"
+	@ssh simulator2 "export QLOGDIR=/home/mihail/logs/fq_codel/fq_intf/no_pacing/ && cd quiche && /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 300000000 > /dev/null && sleep 2"
+	sudo killall quiche-server
+	sudo killall tcpdump
+
+
+
+experiment_2:
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 2 600 && sudo ipfw pipe list"
+	sleep 3
+
+	echo "Testing 1MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/1
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/1 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/1M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 1MB NO CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/1/no_cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/1/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/1M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 2MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/2M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 2MB NO CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/no_cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/2M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 5MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/5
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/5 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/5M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 5MB NO CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/5/no_cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/5/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/5M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB NO CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10/no_cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 20MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/20
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/20 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 20MB NO CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/20/no_cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/20/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 50MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/50
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/50 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/50M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 50MB NO CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/50/no_cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/50/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/50M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 100MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/100
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/100 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 100MB NO CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/100/no_cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/100/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 25 600 && sudo ipfw pipe list"
+	sleep 3
+
+experiment_2_high_IW:
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 2 600 && sudo ipfw pipe list"
+	sleep 10
+
+	echo "Testing 1MB high_IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/1/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/1/high_iw && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/1M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 2MB high_IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/high_iw && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/2M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 5MB high_IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/5/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/5/high_iw && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/5M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB high_IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10/high_iw && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 20MB high_IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/20/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/20/high_iw && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/20M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 50MB high_IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/50/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/50/high_iw && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/50M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 100MB high_IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/100/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/100/high_iw && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 25 600 && sudo ipfw pipe list"
+	sleep 3
+
+exp_2_latest:
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 2 600 && sudo ipfw pipe list"
+
+	echo "Testing 10MB high_IW"
+	mkdir -p /mnt/logs/remote/exp2/high_iw/10
+	export QLOGDIR=/mnt/logs/remote/exp2/high_iw/10 && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..20} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-data 300000000 --max-stream-data 300000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB CR"
+	mkdir -p /mnt/logs/remote/exp2/cr/10
+	export QLOGDIR=/mnt/logs/remote/exp2/cr/10 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..20} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-data 300000000 --max-stream-data 300000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB Cubic"
+	mkdir -p /mnt/logs/remote/exp2/cubic/10
+	export QLOGDIR=/mnt/logs/remote/exp2/cubic/10 && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..20} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-data 300000000 --max-stream-data 300000000 > /dev/null && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+exp_4:
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 2 600 && sudo ipfw pipe list"
+
+	echo "Testing 10MB high_IW"
+	mkdir -p /mnt/logs/remote/exp4/high_iw/10
+	export QLOGDIR=/mnt/logs/remote/exp4/high_iw/10 && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 &
+	export QLOGDIR=/mnt/logs/remote/exp4/high_iw/10 && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..20} ; do python3 exp_4.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB CR"
+	mkdir -p /mnt/logs/remote/exp4/cr/10
+	export QLOGDIR=/mnt/logs/remote/exp4/cr/10 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 &
+	export QLOGDIR=/mnt/logs/remote/exp4/cr/10 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..20} ; do python3 exp_4.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB Cubic"
+	mkdir -p /mnt/logs/remote/exp4/cubic/10
+	export QLOGDIR=/mnt/logs/remote/exp4/cubic/10 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 &
+	export QLOGDIR=/mnt/logs/remote/exp4/cubic/10 && unset PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-data 300000000 --max-stream-data 300000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..20} ; do python3 exp_4.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+exp_2_short:
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 2 600 && sudo ipfw pipe list"
+	sleep 3
+
+	# echo "Testing 10MB CR"
+	# mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/10
+	# export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/10 && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	# @ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	# killall quiche-server && sleep 5
+
+	# echo "Testing 10MB NO CR"
+	# mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/10/no_cr
+	# export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/2/10/no_cr && unset PREVIOUS_CWND_BYTES && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	# @ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 2 ; done"
+	# killall quiche-server && sleep 5
+
+	echo "Testing 10MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10/3/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp2/10/3/high_iw && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/10M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 30 ; done"
+	killall quiche-server && sleep 5
+
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 25 600 && sudo ipfw pipe list"
+	sleep 3
+
+experiment_3:
+	echo "Testing 10MB CR"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/cr && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/cr && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do python3 exp_3.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+	echo "Testing 10MB High IW"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/high_iw && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/high_iw && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1400 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do python3 exp_3.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+	
+
+	echo "Testing 10MB Cubic"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/cubic
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/cubic && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000&
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/10_1/cubic && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do python3 exp_3.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+	echo "Testing 100MB Cubic"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/100_1/cubic
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/100_1/cubic && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/100_1/cubic && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do python3 exp_3.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+exp_3_cr:
+	echo "Starting long flow experiment"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/cr && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/cr && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do python3 exp_3.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+exp_3_high_IW:
+	echo "Starting long flow experiment"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/high_iw
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/high_iw && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	sleep 3 && export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/high_iw && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --initial-cwnd-packets 1390 &
+	@ssh simulator2 "cd quiche &&  for i in {1..6} ; do python3 exp_3.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+# TODO
+exp_3_cubic:
+	echo "Starting long flow experiment"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/cr
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/cr && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/long/cr && export PREVIOUS_CWND_BYTES=1875000 && export PREVIOUS_RTT=600  && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..10} ; do python3 exp_3.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+
+cubic_test:
+	echo "Testing 100MB Cubic"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/test/cubic/tracker
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/test/cubic/tracker && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4430 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/test/cubic/tracker && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do python3 cubic_test.py && sleep 2 ; done"
+	killall quiche-server && sleep 5
+
+cubic_test_no_pacing:
+	echo "Testing 100MB Cubic"
+	mkdir -p /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/test/cubic/no_pacing
+	export QLOGDIR=/home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/logs/remote/exp3/test/cubic/no_pacing && cargo run -F boring --bin quiche-server -- --listen 144.76.191.136:4433 --root /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_q/ --key apps/src/bin/cert.key --cert apps/src/bin/cert.crt --max-stream-data 10000000 --disable-pacing &
+	@ssh simulator2 "cd quiche &&  for i in {1..1} ; do /home/mihail/.cargo/bin/cargo run --bin quiche-client -- https://144.76.191.136:4433/100M.html --no-verify --max-stream-data 10000000 > /dev/null && sleep 5 ; done"
+	killall quiche-server && sleep 5
+
+
+# Experiments
+TRANSFER_SIZES = 020 050 0100 0200 0500 1 2 5 10 20 50
+
+EXP_ROOT=/mnt/logs/new
+
+new_exp_1: config_high_link ${EXP_ROOT}/exp1/cubic_logs_done ${EXP_ROOT}/exp1/cr_logs_done ${EXP_ROOT}/exp1/high_IW_logs_done ${EXP_ROOT}/exp1/IW_30_logs_done
+
+${EXP_ROOT}/exp1/cubic_logs_done: /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/experiment_driver.py
+	echo "Starting simple Cubic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py cubic.json ${QLOG_ROOT}/cubic/$${transfer_size} $${run} $${transfer_size}; \
+			sleep 3; \
+		done \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp1/cr_logs_done: /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/experiment_driver.py
+	echo "Starting simple CR experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py server_cr.json ${QLOG_ROOT}/cr/$${transfer_size} $${run} $${transfer_size}; \
+			sleep 3; \
+		done \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp1/high_IW_logs_done: /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/experiment_driver.py
+	echo "Starting simple High IW experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py high_iw.json ${QLOG_ROOT}/high_iw/$${transfer_size} $${run} $${transfer_size}; \
+			sleep 3; \
+		done \
+	done
+
+	touch ${@}
+
+${EXP_ROOT}/exp1/IW_30_logs_done: /home/mihail/quicoptsat/emulation/quicopsat-stage2/quiche_latest/experiment_driver.py
+	echo "Starting simple IW=30 experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py iw_30.json ${QLOG_ROOT}/iw_30/$${transfer_size} $${run} $${transfer_size}; \
+			sleep 3; \
+		done \
+	done
+
+	touch ${@}
+
+
+new_exp_2: config_low_link ${EXP_ROOT}/exp2/cubic_logs_done ${EXP_ROOT}/exp2/cr_logs_done ${EXP_ROOT}/exp2/high_IW_logs_done ${EXP_ROOT}/exp2/IW_30_logs_done
+
+config_low_link:
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 2 600 && sudo ipfw pipe list"
+	sleep 3
+
+${EXP_ROOT}/exp2/cubic_logs_done:
+	echo "Starting simple Cubic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py cubic.json ${QLOG_ROOT}/cubic/$${transfer_size} $${run} $${transfer_size}; \
+			skeep 3; \
+		done \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp2/cr_logs_done:
+	echo "Starting simple CR experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py server_cr.json ${QLOG_ROOT}/cr/$${transfer_size} $${run} $${transfer_size}; \
+			sleep 3; \
+		done \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp2/high_IW_logs_done:
+	echo "Starting simple High IW experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py high_iw.json ${QLOG_ROOT}/high_iw/$${transfer_size} $${run} $${transfer_size}; \
+			sleep 3; \
+		done \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp2/IW_30_logs_done:
+	echo "Starting simple IW=30 experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for transfer_size in ${TRANSFER_SIZES} ; do \
+		for run in $(shell seq 1 10) ; do \
+			python3 experiment_driver.py iw_30.json ${QLOG_ROOT}/iw_30/$${transfer_size} $${run} $${transfer_size}; \
+			sleep 3; \
+		done \
+	done
+
+	touch ${@}
+
+new_exp_3: config_high_link ${EXP_ROOT}/exp3/cubic_logs_done ${EXP_ROOT}/exp3/cr_logs_done ${EXP_ROOT}/exp3/high_IW_logs_done ${EXP_ROOT}/exp3/IW_30_logs_done
+
+${EXP_ROOT}/background/25Mbps/background_done: config_high_link
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver.py cubic.json ${QLOG_ROOT}/100 $${run} 100; \
+		sleep 3; \
+	done
+
+	touch ${@}
+
+${EXP_ROOT}/background/2Mbps/background_done: config_low_link
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver.py cubic.json ${QLOG_ROOT}/100 $${run} 100; \
+		sleep 3; \
+	done
+
+	touch ${@}
+
+config_high_link:
+	@cat /home/mihail/dummynetpwd | ssh -tt dummynetbox "sudo python3 config_pipes.py 25 600 && sudo ipfw pipe list"
+	sleep 3
+
+${EXP_ROOT}/exp3/cubic_logs_done:
+	echo "Starting simple Cubic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py cubic.json ${QLOG_ROOT}/cubic/10 $${run}; \
+	done
+
+	touch ${@}
+
+${EXP_ROOT}/exp3/cr_logs_done:
+	echo "Starting CR cross traffic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py server_cr.json ${QLOG_ROOT}/cr/10 $${run}; \
+	done
+
+	touch ${@}
+
+${EXP_ROOT}/exp3/high_IW_logs_done:
+	echo "Starting High IW cross traffic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py high_iw.json ${QLOG_ROOT}/high_IW/10 $${run}; \
+	done
+
+	touch ${@}
+
+${EXP_ROOT}/exp3/IW_700_logs_done:
+	echo "Starting simple Cubic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py iw_700.json ${QLOG_ROOT}/iw_700/10 $${run}; \
+	done
+
+	touch ${@}
+
+${EXP_ROOT}/exp3/IW_30_logs_done:
+	echo "Starting IW=30 cross traffic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py iw_30.json ${QLOG_ROOT}/IW_30/10 $${run}; \
+	done
+
+	touch ${@}
+
+
+new_exp_4: config_low_link ${EXP_ROOT}/exp4/cubic_logs_done ${EXP_ROOT}/exp4/cr_logs_done ${EXP_ROOT}/exp4/high_IW_logs_done ${EXP_ROOT}/exp4/IW_30_logs_done
+
+
+${EXP_ROOT}/exp4/cubic_logs_done:
+	echo "Starting simple Cubic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py cubic.json ${QLOG_ROOT}/cubic/10 $${run}; \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp4/cr_logs_done:
+	echo "Starting CR cross traffic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py server_cr.json ${QLOG_ROOT}/cr/10 $${run}; \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp4/high_IW_logs_done:
+	echo "Starting High IW cross traffic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py high_iw.json ${QLOG_ROOT}/high_IW/10 $${run}; \
+	done
+
+	touch ${@}
+
+${EXP_ROOT}/exp4/IW_700_logs_done:
+	echo "Starting simple Cubic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py iw_700.json ${QLOG_ROOT}/iw_700/10 $${run}; \
+	done
+
+	touch ${@}
+
+
+${EXP_ROOT}/exp4/IW_30_logs_done:
+	echo "Starting IW=30 cross traffic experiment"
+	$(eval QLOG_ROOT := $(shell dirname ${@}))
+	mkdir -p ${QLOG_ROOT}
+
+	for run in $(shell seq 1 10) ; do \
+		python3 experiment_driver_cross.py iw_30.json ${QLOG_ROOT}/IW_30/10 $${run}; \
+	done
+
+	touch ${@}
+
+
+# Figures
+
+/mnt/parsed/exp1/FCT_parsed: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/parsers/parse_FCT_pcap.py /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/helpers/get_partial_completion_offset.py ${EXP_ROOT}/exp1/cubic_logs_done ${EXP_ROOT}/exp1/cr_logs_done ${EXP_ROOT}/exp1/high_IW_logs_done
+	mkdir -p ${@D}
+	python3 ${<} exp1
+
+	touch ${@}
+
+exp_1_outputs: /mnt/parsed/exp1/FCT_parsed
+	@echo "Outputs done"
+
+/mnt/parsed/exp2/FCT_parsed: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/parsers/parse_FCT_pcap.py /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/helpers/get_partial_completion_offset.py ${EXP_ROOT}/exp2/cr_logs_done ${EXP_ROOT}/exp2/high_IW_logs_done
+	mkdir -p ${@D}
+	python3 ${<} exp2
+
+	touch ${@}
+
+exp_2_outputs: /mnt/parsed/exp2/FCT_parsed
+	@echo "Outputs done"
+
+/mnt/parsed/exp3/loss_stats_parsed: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/parsers/parse_loss_stats.py ${EXP_ROOT}/exp1/cubic_logs_done ${EXP_ROOT}/exp1/cr_logs_done ${EXP_ROOT}/exp1/high_IW_logs_done
+	mkdir -p ${@D}
+	python3 ${<} exp3
+	touch ${@}
+
+
+/mnt/parsed/exp3/FCT_parsed: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/parsers/parse_FCT_pcap_cross.py ${EXP_ROOT}/exp1/cubic_logs_done ${EXP_ROOT}/exp1/cr_logs_done ${EXP_ROOT}/exp1/high_IW_logs_done
+	mkdir -p ${@D}
+	python3 ${<} exp3
+	touch ${@}
+
+
+exp_3_outputs: /mnt/parsed/exp3/loss_stats_parsed
+	@echo "Outputs done"
+
+/mnt/parsed/exp4/loss_stats_parsed: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/parsers/parse_loss_stats.py ${EXP_ROOT}/exp1/cubic_logs_done ${EXP_ROOT}/exp1/cr_logs_done ${EXP_ROOT}/exp1/high_IW_logs_done
+	mkdir -p ${@D}
+	python3 ${<} exp4
+	touch ${@}
+
+/mnt/parsed/exp4/FCT_parsed: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/parsers/parse_FCT_pcap_cross.py ${EXP_ROOT}/exp4/cubic_logs_done ${EXP_ROOT}/exp4/cr_logs_done ${EXP_ROOT}/exp4/high_IW_logs_done
+	mkdir -p ${@D}
+	python3 ${<} exp4
+	touch ${@}
+
+exp_4_outputs: /mnt/parsed/exp4/loss_stats_parsed
+	@echo "Outputs done"
+
+
+/mnt/plots/FCT_exp1.png /mnt/plots/FCT_exp1.pdf: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/generators/plot_FCT.py /mnt/parsed/exp1/FCT_parsed
+	python3 ${<} /mnt/parsed/exp1 ${@}
+
+/mnt/plots/FCT_exp2.png /mnt/plots/FCT_exp2.pdf: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/generators/plot_FCT.py /mnt/parsed/exp2/FCT_parsed
+	python3 ${<} /mnt/parsed/exp2 ${@}
+
+/mnt/plots/FCT_stats_cross_exp3.txt: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/generators/FCT_stats_cross.py /mnt/parsed/exp3/FCT_parsed
+	python3 ${<} /mnt/parsed/exp3 > ${@}
+
+/mnt/plots/FCT_stats_cross_exp4.txt: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/generators/FCT_stats_cross.py /mnt/parsed/exp4/FCT_parsed
+	python3 ${<} /mnt/parsed/exp4 > ${@}
+
+
+/mnt/plots/exp3_loss.txt: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/generators/latex_table_generator.py exp_3_outputs
+	python3 ${<} ${@} /mnt/parsed/exp3/loss_stats.json
+	@echo "Done"
+
+exp_3_table: /mnt/plots/exp3_loss.txt
+
+/mnt/plots/exp4_loss.txt: /home/mihail/quicoptsat/emulation/quicopsat-stage2/scripts/processing/generators/latex_table_generator.py exp_4_outputs
+	python3 ${<} ${@} /mnt/parsed/exp4/loss_stats.json
+	@echo "Done"
+
+exp_4_table: /mnt/plots/exp4_loss.txt
+
+
+test:
+	mkdir -p /mnt/logs/test/cr/10
+	python3 experiment_driver.py server_cr.json /mnt/logs/test/cr/10 1 10

--- a/apps/src/common.rs
+++ b/apps/src/common.rs
@@ -150,8 +150,11 @@ fn autoindex(path: path::PathBuf, index: &str) -> path::PathBuf {
 pub fn make_qlog_writer(
     dir: &std::ffi::OsStr, role: &str, id: &str,
 ) -> std::io::BufWriter<std::fs::File> {
+    // Add UNIX timestamp to name so multiple qlogs are easily sortable by creation time
+    let time_offset = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs_f64();
+
     let mut path = std::path::PathBuf::from(dir);
-    let filename = format!("{role}-{id}.sqlog");
+    let filename = format!("{time_offset}_{role}-{id}.sqlog");
     path.push(filename);
 
     match std::fs::File::create(&path) {

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -764,6 +764,8 @@ pub struct MetricsUpdated {
     pub packets_in_flight: Option<u64>,
 
     pub pacing_rate: Option<u64>,
+
+    pub lost_count: Option<usize>,
 }
 
 #[serde_with::skip_serializing_none]

--- a/qlog/src/events/quic.rs
+++ b/qlog/src/events/quic.rs
@@ -766,6 +766,8 @@ pub struct MetricsUpdated {
     pub pacing_rate: Option<u64>,
 
     pub lost_count: Option<usize>,
+
+    pub cubic_state: Option<u64>,
 }
 
 #[serde_with::skip_serializing_none]

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -5349,7 +5349,7 @@ impl Connection {
     #[inline]
     pub fn stream_capacity(&self, stream_id: u64) -> Result<usize> {
         if let Some(stream) = self.streams.get(stream_id) {
-            let cap = cmp::min(self.tx_cap, stream.send.cap()?);
+            let cap = stream.send.cap()?; //cmp::min(self.tx_cap, stream.send.cap()?);
             return Ok(cap);
         };
 
@@ -7716,8 +7716,8 @@ impl Connection {
             Err(_) => 0,
         };
 
-        self.tx_cap =
-            cmp::min(cwin_available, self.max_tx_data - self.tx_data) as usize;
+        self.tx_cap = (self.max_tx_data - self.tx_data) as usize;
+            // cmp::min(cwin_available, self.max_tx_data - self.tx_data) as usize;
     }
 
     fn delivery_rate_check_if_app_limited(&self) -> bool {

--- a/quiche/src/lib.rs
+++ b/quiche/src/lib.rs
@@ -1596,7 +1596,9 @@ pub struct Connection {
 
     cr_event: Option<recovery::CREvent>,
 
-    default_stream_window: Option<u64>
+    default_stream_window: Option<u64>,
+
+    using_resume: bool,
 }
 
 /// Creates a new server-side connection.
@@ -2056,6 +2058,8 @@ impl Connection {
             cr_event: None,
 
             default_stream_window: None,
+
+            using_resume: config.resume,
         };
 
         if let Some(odcid) = odcid {
@@ -2168,6 +2172,8 @@ impl Connection {
 
         self.qlog.level = level;
 
+        let time_offset = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs_f64();
+
         let trace = qlog::TraceSeq::new(
             qlog::VantagePoint {
                 name: None,
@@ -2177,7 +2183,7 @@ impl Connection {
             Some(title.to_string()),
             Some(description.to_string()),
             Some(qlog::Configuration {
-                time_offset: Some(0.0),
+                time_offset: Some(time_offset),
                 original_uris: None,
             }),
             None,

--- a/quiche/src/recovery/congestion/cubic.rs
+++ b/quiche/src/recovery/congestion/cubic.rs
@@ -39,6 +39,7 @@ use std::time::Instant;
 use crate::recovery;
 use crate::recovery::rtt::RttStats;
 use crate::recovery::Acked;
+use crate::recovery::congestion::resume::CrState;
 use crate::recovery::Sent;
 
 use super::reno;
@@ -237,7 +238,18 @@ fn on_packet_acked(
                 r.congestion_window +=
                     r.hystart.css_cwnd_inc(r.max_datagram_size);
             } else {
-                r.congestion_window += r.max_datagram_size;
+                if r.resume.enabled() {
+                    let cr_state = r.resume.get_state();
+                    match cr_state {
+                        CrState::Unvalidated(_) => {}
+                        CrState::SafeRetreat(_) => {}
+                        _ => {
+                            r.congestion_window += r.max_datagram_size;
+                        }
+                    }
+                } else {
+                    r.congestion_window += r.max_datagram_size;
+                }
             }
 
             r.bytes_acked_sl -= r.max_datagram_size;

--- a/quiche/src/recovery/congestion/cubic.rs
+++ b/quiche/src/recovery/congestion/cubic.rs
@@ -146,7 +146,9 @@ impl State {
     }
 }
 
-fn on_init(_r: &mut Congestion) {}
+fn on_init(_r: &mut Congestion) {
+    _r.hystart.cc_state = 0;
+}
 
 fn on_packet_sent(
     r: &mut Congestion, sent_bytes: usize, bytes_in_flight: usize, now: Instant,
@@ -260,6 +262,7 @@ fn on_packet_acked(
             r.ssthresh = r.congestion_window;
         }
     } else {
+        r.hystart.cc_state = 2;
         // Congestion avoidance.
         let ca_start_time;
 

--- a/quiche/src/recovery/congestion/hystart.rs
+++ b/quiche/src/recovery/congestion/hystart.rs
@@ -64,6 +64,8 @@ pub struct Hystart {
     css_start_time: Option<Instant>,
 
     css_round_count: usize,
+
+    pub cc_state: u64,
 }
 
 impl std::fmt::Debug for Hystart {
@@ -133,6 +135,7 @@ impl Hystart {
 
         // Slow Start.
         if self.css_start_time().is_none() {
+            self.cc_state = 0;
             if self.rtt_sample_count >= N_RTT_SAMPLE &&
                 self.current_round_min_rtt != Duration::MAX &&
                 self.last_round_min_rtt != Duration::MAX
@@ -153,6 +156,7 @@ impl Hystart {
             }
         } else {
             // Conservative Slow Start.
+            self.cc_state = 1;
             if self.rtt_sample_count >= N_RTT_SAMPLE {
                 self.rtt_sample_count = 0;
 
@@ -160,6 +164,7 @@ impl Hystart {
                     self.css_baseline_min_rtt = Duration::MAX;
 
                     // Back to Slow Start.
+                    self.cc_state = 0;
                     self.css_start_time = None;
                     self.css_round_count = 0;
                 }
@@ -177,6 +182,7 @@ impl Hystart {
 
                     // End of CSS - exit to congestion avoidance.
                     if self.css_round_count >= CSS_ROUNDS {
+                        self.cc_state = 2;
                         self.css_round_count = 0;
                         return true;
                     }
@@ -194,6 +200,7 @@ impl Hystart {
 
     // Exit HyStart++ when entering congestion avoidance.
     pub fn congestion_event(&mut self) {
+        self.cc_state = 2;
         self.window_end = None;
         self.css_start_time = None;
     }

--- a/quiche/src/recovery/congestion/resume.rs
+++ b/quiche/src/recovery/congestion/resume.rs
@@ -74,6 +74,9 @@ impl Resume {
             false
         }
     }
+    pub fn get_state(&self) -> CrState {
+        self.cr_state
+    }
 
     #[inline]
     fn change_state(&mut self, state: CrState, trigger: CarefulResumeTrigger) {

--- a/quiche/src/recovery/congestion/resume.rs
+++ b/quiche/src/recovery/congestion/resume.rs
@@ -25,6 +25,7 @@ pub struct Resume {
     previous_rtt: Duration,
     previous_cwnd: usize,
     pipesize: usize,
+    pub total_acked: usize,
 
     #[cfg(feature = "qlog")]
     qlog_metrics: QlogMetrics,
@@ -52,7 +53,7 @@ impl Resume {
             previous_rtt: Duration::ZERO,
             previous_cwnd: 0,
             pipesize: 0,
-
+            total_acked: 0,
             #[cfg(feature = "qlog")]
             qlog_metrics: QlogMetrics::default(),
             #[cfg(feature = "qlog")]
@@ -90,6 +91,7 @@ impl Resume {
     pub fn process_ack(
         &mut self, largest_pkt_sent: u64, packet: &Acked, flightsize: usize
     ) -> (Option<usize>, Option<usize>) {
+        self.total_acked += packet.size;
         match self.cr_state {
             CrState::Unvalidated(first_packet) => {
                 self.pipesize += packet.size;
@@ -131,14 +133,16 @@ impl Resume {
     }
 
     pub fn send_packet(
-        &mut self, rtt_sample: Option<Duration>, cwnd: usize, largest_pkt_sent: u64, app_limited: bool,
+        &mut self, rtt_sample: Option<Duration>, cwnd: usize, largest_pkt_sent: u64, app_limited: bool, iw_acked: bool
     ) -> usize {
         // Do nothing when data limited to avoid having insufficient data
         // to be able to validate transmission at a higher rate
         if app_limited {
             return 0;
         }
-
+        if !iw_acked {
+            return 0;
+        }
         if self.cr_state == CrState::Reconnaissance {
             let jump = (self.previous_cwnd / 2).saturating_sub(cwnd);
 
@@ -389,7 +393,7 @@ mod tests {
     fn cwnd_larger_than_jump() {
         let mut r = Resume::new("");
         r.setup(Duration::from_millis(50), 80_000);
-        r.send_packet(Some(Duration::from_millis(50)), 45_000, 50, false);
+        r.send_packet(Some(Duration::from_millis(50)), 45_000, 50, false, true);
 
         assert_eq!(r.cr_state, CrState::Normal);
     }
@@ -399,7 +403,7 @@ mod tests {
     fn rtt_less_than_half() {
         let mut r = Resume::new("");
         r.setup(Duration::from_millis(50), 80_000);
-        r.send_packet(Some(Duration::from_millis(10)), 30_000, 10, false);
+        r.send_packet(Some(Duration::from_millis(10)), 30_000, 10, false, true);
 
         assert_eq!(r.cr_state, CrState::Normal);
     }
@@ -408,7 +412,7 @@ mod tests {
     fn rtt_greater_than_10() {
         let mut r = Resume::new("");
         r.setup(Duration::from_millis(50), 80_000);
-        r.send_packet(Some(Duration::from_millis(600)), 30_000, 10, false);
+        r.send_packet(Some(Duration::from_millis(600)), 30_000, 10, false, true);
 
         assert_eq!(r.cr_state, CrState::Normal);
     }
@@ -418,7 +422,7 @@ mod tests {
     fn valid_rtt() {
         let mut r = Resume::new("");
         r.setup(Duration::from_millis(50), 80_000);
-        let jump = r.send_packet(Some(Duration::from_millis(60)), 20_500, 20, false);
+        let jump = r.send_packet(Some(Duration::from_millis(60)), 20_500, 20, false, true);
         assert_eq!(jump, 19_500);
 
         assert_eq!(r.cr_state, CrState::Unvalidated(20));
@@ -685,6 +689,204 @@ mod tests {
 
         assert_eq!(r.congestion.resume.cr_state, CrState::Unvalidated(15));
         assert_eq!(r.congestion.resume.pipesize, 12_000);
+    }
+    #[test]
+    fn mj_cr_test() {
+        let mut cfg = crate::Config::new(crate::PROTOCOL_VERSION).unwrap();
+
+        let max_datagram_size = 1350;
+
+        cfg.set_max_recv_udp_payload_size(max_datagram_size);
+        cfg.set_max_send_udp_payload_size(max_datagram_size);
+
+        cfg.set_cc_algorithm(CongestionControlAlgorithm::CUBIC);
+        cfg.enable_hystart(true);
+        cfg.enable_resume(true);
+
+        let mut r = Recovery::new(&cfg, "");
+        let mut now = Instant::now();
+
+        // Once the initial handshake is established we have an RTT sample
+        r.update_rtt(Duration::from_millis(50), Duration::from_millis(0), now);
+
+        r.setup_careful_resume(Duration::from_millis(50), 600_000);
+
+        assert_eq!(r.sent[packet::Epoch::Application].len(), 0);
+
+        // Send packets to fill the cwnd
+        for i in 0..9 {
+            let p = Sent {
+                pkt_num: i as u64,
+                frames: smallvec![],
+                time_sent: now,
+                time_acked: None,
+                time_lost: None,
+                size: 1350,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
+                has_data: false,
+                pmtud: false,
+            };
+
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+            assert_eq!(r.congestion.sent[packet::Epoch::Application].len(), i + 1);
+            assert_eq!(r.bytes_in_flight, max_datagram_size * (i + 1));
+        }
+
+        assert_eq!(r.congestion.resume.cr_state, CrState::Reconnaissance);
+
+        // Send enough data to ensure bytes sent > cwnd
+        let p = Sent {
+            pkt_num: 10 as u64,
+            frames: smallvec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: 500,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            has_data: false,
+            pmtud: false,
+        };
+
+        r.on_packet_sent(
+            p,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            now,
+            "",
+        );
+        assert_eq!(r.bytes_in_flight, 9 * 1350 + 500);
+
+        assert_eq!(r.congestion.resume.cr_state, CrState::Reconnaissance);
+
+        let p = Sent {
+            pkt_num: 10 as u64,
+            frames: smallvec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: 850,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            has_data: false,
+            pmtud: false,
+        };
+
+        r.on_packet_sent(
+            p,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            now,
+            "",
+        );
+
+        assert_eq!(false, r.congestion.app_limited);
+        // make sure we are still in reconnaissance
+        assert_eq!(r.congestion.resume.cr_state, CrState::Reconnaissance);
+
+
+        let mut acked = ranges::RangeSet::default();
+        acked.insert(0..10 as u64);
+
+        now += Duration::from_millis(50);
+
+        let _ = r.congestion.on_ack_received(
+            &acked,
+            0,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            now,
+            "",
+            &mut Vec::new(),
+        );
+
+        // Send enough packets to fill the pipe
+        for i in 0..20 {
+            let p = Sent {
+                pkt_num: 12 + i as u64,
+                frames: smallvec![],
+                time_sent: now,
+                time_acked: None,
+                time_lost: None,
+                size: 1350,
+                ack_eliciting: true,
+                in_flight: true,
+                delivered: 0,
+                delivered_time: now,
+                first_sent_time: now,
+                is_app_limited: false,
+                tx_in_flight: 0,
+                lost: 0,
+                has_data: false,
+                pmtud: false,
+            };
+
+            r.on_packet_sent(
+                p,
+                packet::Epoch::Application,
+                HandshakeStatus::default(),
+                now,
+                "",
+            );
+            assert_eq!(r.bytes_in_flight, max_datagram_size * (i + 1));
+        }
+
+        let p = Sent {
+            pkt_num: 32 as u64,
+            frames: smallvec![],
+            time_sent: now,
+            time_acked: None,
+            time_lost: None,
+            size: 1350,
+            ack_eliciting: true,
+            in_flight: true,
+            delivered: 0,
+            delivered_time: now,
+            first_sent_time: now,
+            is_app_limited: false,
+            tx_in_flight: 0,
+            lost: 0,
+            has_data: false,
+            pmtud: false,
+        };
+
+        r.on_packet_sent(
+            p,
+            packet::Epoch::Application,
+            HandshakeStatus::default(),
+            now,
+            "",
+        );
+
+        assert_eq!(r.congestion.resume.cr_state, CrState::Unvalidated(31));
+        assert_eq!(r.cwnd(), 300_000);
+
+
     }
     #[test]
     fn invalid_rtt_full() {

--- a/quiche/src/recovery/congestion/resume.rs
+++ b/quiche/src/recovery/congestion/resume.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 use qlog::events::EventData;
 use qlog::events::resume::*;
 use crate::recovery::Acked;
+use std::convert::TryInto;
 
 const CR_EVENT_MAXIMUM_GAP: Duration = Duration::from_secs(60);
 
@@ -46,12 +47,41 @@ impl std::fmt::Debug for Resume {
 
 impl Resume {
     pub fn new(trace_id: &str) -> Self {
+
+        // enabled will become false if either of the required CR ENV VARS is not supplied
+        let mut enabled = true;
+
+        let mut previous_rtt = Duration::ZERO;
+        let mut previous_cwnd = 0;
+
+        if let Some(jw_oss) = std::env::var_os("PREVIOUS_CWND_BYTES")
+        {
+            if let Ok(jw_string) = jw_oss.into_string() {
+                if let Ok(jw_int) = jw_string.parse::<usize>() {
+                    previous_cwnd = jw_int;
+                }
+            }
+        } else {
+            enabled = false;
+        }
+
+        if let Some(rtt_oss) = std::env::var_os("PREVIOUS_RTT") 
+        {
+            if let Ok(rtt_string) = rtt_oss.into_string() {
+                if let Ok(rtt_int) = rtt_string.parse::<usize>() {
+                    previous_rtt = Duration::from_millis(rtt_int.try_into().unwrap());
+                }
+            }
+        } else {
+            enabled = false;
+        }
+
         Self {
             trace_id: trace_id.to_string(),
-            enabled: false,
+            enabled: enabled,
             cr_state: CrState::default(),
-            previous_rtt: Duration::ZERO,
-            previous_cwnd: 0,
+            previous_rtt: previous_rtt,
+            previous_cwnd: previous_cwnd,
             pipesize: 0,
             total_acked: 0,
             #[cfg(feature = "qlog")]

--- a/quiche/src/recovery/congestion/resume.rs
+++ b/quiche/src/recovery/congestion/resume.rs
@@ -125,6 +125,10 @@ impl Resume {
         self.cr_state
     }
 
+    pub fn get_previous_cwnd(&self) -> f64 {
+        self.previous_cwnd as f64
+    }
+
     #[inline]
     fn change_state(&mut self, state: CrState, trigger: CarefulResumeTrigger) {
         self.cr_state = state;

--- a/quiche/src/recovery/congestion/resume.rs
+++ b/quiche/src/recovery/congestion/resume.rs
@@ -32,6 +32,8 @@ pub struct Resume {
     qlog_metrics: QlogMetrics,
     #[cfg(feature = "qlog")]
     last_trigger: Option<CarefulResumeTrigger>,
+
+    use_sr: bool,
 }
 
 impl std::fmt::Debug for Resume {
@@ -50,6 +52,7 @@ impl Resume {
 
         // enabled will become false if either of the required CR ENV VARS is not supplied
         let mut enabled = true;
+        let mut use_sr = true;
 
         let mut previous_rtt = Duration::ZERO;
         let mut previous_cwnd = 0;
@@ -76,6 +79,18 @@ impl Resume {
             enabled = false;
         }
 
+        if let Some(no_sr_oss) = std::env::var_os("DISABLE_SR")
+        {
+            if let Ok(no_sr_string) = no_sr_oss.into_string() {
+                if let Ok(no_sr_int) = no_sr_string.parse::<usize>() {
+                    if no_sr_int == 1 {
+                        println!("Disabling SR");
+                        use_sr = false;
+                    }
+                }
+            }
+        }
+
         Self {
             trace_id: trace_id.to_string(),
             enabled: enabled,
@@ -87,7 +102,8 @@ impl Resume {
             #[cfg(feature = "qlog")]
             qlog_metrics: QlogMetrics::default(),
             #[cfg(feature = "qlog")]
-            last_trigger: None
+            last_trigger: None,
+            use_sr,
         }
     }
 
@@ -218,16 +234,27 @@ impl Resume {
 
                 // TODO: mark used CR parameters as invalid for future connections
 
-                self.change_state(CrState::SafeRetreat(largest_pkt_sent), CarefulResumeTrigger::PacketLoss);
-                self.pipesize / 2
+                if self.use_sr {
+                    self.change_state(CrState::SafeRetreat(largest_pkt_sent), CarefulResumeTrigger::PacketLoss);
+                    self.pipesize / 2
+                } else {
+                    self.change_state(CrState::Normal, CarefulResumeTrigger::PacketLoss);
+                    0
+                }
             }
             CrState::Validating(p) => {
                 trace!("{} congestion during validating phase", self.trace_id);
 
                 // TODO: mark used CR parameters as invalid for future connections
 
-                self.change_state(CrState::SafeRetreat(p), CarefulResumeTrigger::PacketLoss);
-                self.pipesize / 2
+                if self.use_sr {
+                    self.change_state(CrState::SafeRetreat(p), CarefulResumeTrigger::PacketLoss);
+                    self.pipesize / 2
+                } else {
+                    self.change_state(CrState::Normal, CarefulResumeTrigger::PacketLoss);
+                    0
+                }
+
             }
             CrState::Reconnaissance => {
                 trace!("{} congestion during reconnaissance - abandoning careful resume", self.trace_id);


### PR DESCRIPTION
This pull request allows for CR state control using environment variables, modifies qlog naming, and adds a patch to allow full use of CWND during unbalidated. 

The configurable options via env variables are:
1. The "stored" previous cwnd, in bytes (PREVIOUS_CWND_BYTES)
2. the "stored" RTT (PREVIOUS_RTT)
3. Whether safe retreat should be used (DISABLE_SR)

The qlogs naming format is now the following {UNIX_TIMESTAMP_ROLE_CID.[s]qlog}. The patch adds UNIX_TIMESTAMP and allows one to identify easier the newest qlog.

Finally, this patch resolves an issue where the sender was not able to use the full CWND during the unvalidated phase and was entering validating prematurely. This happened because the transmit cap is controlled by the supplied max-stream-data parameter, the cwnd, and an additional transmit calculation. I have forced the the transmit cap to **always** be the supplied max-stream-data parameter. This is safe since the transport layer ensures that **at most** cwnd bytes are in-flight at any given time. There is a better way to resolve this by dynamically recalculating the tx_cap when cwnd updates, but for testing purposes this patch resolves the issue.